### PR TITLE
Add default keyword to setting

### DIFF
--- a/lib/log_book/configuration.rb
+++ b/lib/log_book/configuration.rb
@@ -1,10 +1,10 @@
 module LogBook
   extend Dry::Configurable
 
-  setting :records_table_name,    'records'
-  setting :ignored_attributes,    [:updated_at, :created_at]
-  setting :always_record,         false
-  setting :author_method,         :current_user
-  setting :record_squashing,      false
-  setting :skip_if_empty_actions, [:update]
+  setting :records_table_name,    default: 'records'
+  setting :ignored_attributes,    default: [:updated_at, :created_at]
+  setting :always_record,         default: false
+  setting :author_method,         default: :current_user
+  setting :record_squashing,      default: false
+  setting :skip_if_empty_actions, default: [:update]
 end

--- a/log_book.gemspec
+++ b/log_book.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activerecord', '> 5.2'
   spec.add_dependency 'activesupport', '> 5.2'
-  spec.add_dependency 'dry-configurable'
+  spec.add_dependency 'dry-configurable', '> 0.12'
 end


### PR DESCRIPTION
Add default: keyword to settings to remove dry-configurable warnings